### PR TITLE
Call parent's __init__ function from derived class

### DIFF
--- a/ops.py
+++ b/ops.py
@@ -39,6 +39,8 @@ class HdrRotationOperator(RayCast):
     bl_options = {'UNDO'}
 
     def __init__(self):
+        super().__init__()
+
         shading = self.shading = bpy.context.space_data.shading
         is_material = (shading.type == 'MATERIAL' and shading.use_scene_world)
         is_rendered = (shading.type == 'RENDERED' and shading.use_scene_world_render)


### PR DESCRIPTION
Fix https://github.com/AIGODLIKE/hdr_rotation/issues/6

Ref: https://developer.blender.org/docs/release_notes/4.4/python_api/#subclassing-blender-types